### PR TITLE
Fix profile creation by preserving target user policy

### DIFF
--- a/Controllers/ProfilesController.cs
+++ b/Controllers/ProfilesController.cs
@@ -264,8 +264,9 @@ namespace Jellyfin.Profiles.Controllers
             var masterPolicy = masterUserDto.Policy;
             var masterConfig = masterUserDto.Configuration;
 
-            // Build target policy
-            var targetPolicy = new UserPolicy();
+            // Build target policy from the newly created Jellyfin user so required provider fields are preserved
+            var targetUserDto = _userManager.GetUserDto(targetUser, string.Empty);
+            var targetPolicy = targetUserDto.Policy;
             CopyUserPolicy(masterPolicy, targetPolicy);
             targetPolicy.IsAdministrator = false;
             targetPolicy.IsHidden = true;


### PR DESCRIPTION
The failure was caused by CreateProfile() initializing the target policy with new UserPolicy(), which left AuthenticationProviderId null. Jellyfin 10.11 rejects that during UpdatePolicyAsync because Users.AuthenticationProviderId is NOT NULL.

The fix initializes the target policy from the newly created user's existing DTO policy before applying Bonfire's copied settings.